### PR TITLE
fix dead links in "Download the latest build" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Several quick start options are available:
 #### Download the latest build
 
 ###### Development
- * [toolslide.js](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/js/toolslide.js)
- * [toolslide.css](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/css/toolslide.css)
+ * [toolslide.js](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/toolslide.js)
+ * [toolslide.css](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/toolslide.css)
 
 ###### Production
- * [toolslide.min.js](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/js/toolslide.min.js)
- * [toolslide.min.css](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/css/toolslide.min.css)
+ * [toolslide.min.js](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/toolslide.min.js)
+ * [toolslide.min.css](https://raw.githubusercontent.com/karenpommeroy/toolslide.js/master/dist/toolslide.min.css)
 
 #### Install From Bower
 ```sh


### PR DESCRIPTION
All the links to your raw files contained js/css folders which you seem to have removed in the past. Should all be good now.